### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   },
   "dependencies": {
     "react": "^15.3.0",
-    "react-dom": "^15.3.0"
+    "react-dom": "^15.3.0",
+    "react-test-renderer": "^15.5.4"
   }
 }


### PR DESCRIPTION
Kept getting error `Error: Cannot find module 'react-test-renderer/shallow'` on running `npm run bundle`

Adding `react-test-renderer` to package.json allowed me to run `npm run bundle` and successfully compile javascript with browserify.

Tested on node version 6.6.0 and npm version 3.10.3